### PR TITLE
Fix first link to info on making a Sia address

### DIFF
--- a/get-started-with-sia/how-to-buy-siacoins.md
+++ b/get-started-with-sia/how-to-buy-siacoins.md
@@ -25,7 +25,7 @@ If this is your first time purchasing crypto, start with a small amount until yo
 {% endhint %}
 
 * Now you have the Siacoins in your Bittrex wallet, but exchange wallets aren’t a good place to store crypto, and you can’t use it for its intended purpose - using Sia.
-* Transfer to your Sia wallet by [making a Sia address](how-to-buy-siacoins.md) and then sending to it from Bittrex.
+* Transfer to your Sia wallet by [making a Sia address](../your-sia-wallet/how-to-make-a-sia-address.md) and then sending to it from Bittrex.
 
 ## Buy SC using Transak
 


### PR DESCRIPTION
This link led to the same page the user was on, though a new user might expect that link to instead lead to info on how to make a Sia address. The second such link on this page behaves correctly. This PR corrects the first link to match the behavior of the second.